### PR TITLE
Added ShouldVerify Middleware

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use MakelarisJR\Laravel2FA\Http\Controllers\Verify2FAController;
 
 Route::group(['middleware' => 'throttle:100'], function() {
     Route::view('/verify', 'laravel2fa::verify')
+        ->middleware(\MakelarisJR\Laravel2FA\Http\Middleware\ShouldVerify::class)
         ->name('verify2fa');
     Route::post('/verify', Verify2FAController::class)
         ->name('verify2fa.post')->middleware('throttle:10');

--- a/src/Http/Middleware/ShouldVerify.php
+++ b/src/Http/Middleware/ShouldVerify.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MakelarisJR\Laravel2FA\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Session;
+
+class ShouldVerify
+{
+    /**
+     * @param Request $request
+     * @param Closure $next
+     * @return \Illuminate\Http\RedirectResponse|mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+
+        if (! $user->has2FAEnabled() or Session::has('2fa_passed'))
+        {
+            return redirect(
+                config('laravel2fa.default_redirect', '/dashboard')
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/ShouldVerify.php
+++ b/src/Http/Middleware/ShouldVerify.php
@@ -18,7 +18,7 @@ class ShouldVerify
     {
         $user = $request->user();
 
-        if (! $user->has2FAEnabled() or Session::has('2fa_passed'))
+        if (! $user->has2FAEnabled() || Session::has('2fa_passed'))
         {
             return redirect(
                 config('laravel2fa.default_redirect', '/dashboard')


### PR DESCRIPTION
This middleware ensures that the /verify route cannot be visited by users that are already 2fa-verifies or if they dont use 2fa at all. 