### PR TITLE
Change dates to casts to support new Laravel version

### DIFF
--- a/src/Models/OtpBackupCode.php
+++ b/src/Models/OtpBackupCode.php
@@ -21,8 +21,8 @@ class OtpBackupCode extends Model
 {
     protected $fillable = ['code', 'used_at'];
 
-    protected $dates = [
-        'used_at',
+    protected $casts = [
+        'used_at' => 'datetime',
     ];
 
     public function model(): MorphTo


### PR DESCRIPTION
This PR addresses the deprecation of the $dates property in the package. I have migrated to the recommended $casts for improved attribute handling. This ensures compliance with Laravel best practices and guarantees a smooth transition without disruptions. Your feedback on this update is appreciated.